### PR TITLE
Add whois.ja.net for gov.wales, llyw.cymru, and gov.scot

### DIFF
--- a/example/jwhois.conf
+++ b/example/jwhois.conf
@@ -347,6 +347,7 @@ whois-servers {
 	"\\.cx$" = "whois.nic.cx";
 	"\\.cy$" = "whois.ripe.net";
 	"\\.cymru$" = "whois.nic.cymru";
+		"\\.llyw\\.cymru$" = "whois.ja.net";
 	"\\.cyou$" = "whois.afilias-srs.net";
 	"\\.cz$" = "whois.nic.cz";
 	"\\.dabur$" = "whois.afilias-srs.net";
@@ -846,6 +847,7 @@ whois-servers {
 	"\\.science$" = "whois.nic.science";
 	"\\.scor$" = "whois.nic.scor";
 	"\\.scot$" = "whois.scot.coreregistry.net";
+		"\\.gov\\.scot$" = "whois.ja.net";
 	"\\.se$" = "whois.iis.se";
 		"\\.com\\.se$" = "whois.centralnic.com";
 	"\\.seat$" = "whois.nic.seat";
@@ -1013,6 +1015,7 @@ whois-servers {
 	"\\.voyage$" = "whois.donuts.co";
 	"\\.vu$" = "vunic.vu";
 	"\\.wales$" = "whois.nic.wales";
+		"\\.gov\\.wales$" = "whois.ja.net";
 	"\\.walter$" = "whois.nic.walter";
 	"\\.wang$" = "whois.gtld.knet.cn";
 	"\\.watch$" = "whois.donuts.co";


### PR DESCRIPTION
These domains are all devolved government subdomains managed by the UK's Jisc's JANET service, who provide a separate whois service for their registry.

This can be confirmed by running:

```sh
$ dig gov.wales SOA
$ dig llyw.cymru SOA
$ dig gov.scot SOA
```

In turn these return answers like this:

```
llyw.cymru.		3600	IN	SOA	ns0.ja.net. operations.ja.net. 2021091730 28800 7200 3600000 600
gov.wales.		3600	IN	SOA	ns0.ja.net. operations.ja.net. 2021091730 28800 7200 3600000 600
gov.scot.		3600	IN	SOA	ns0.ja.net. operations.ja.net. 2021101560 28800 7200 3600000 14400
```

To validate that whois.ja.net responds for these domains, see:

```sh
$ whois -h whois.ja.net service.gov.wales
$ whois -h whois.ja.net eryri.llyw.cymru
$ whois -h whois.ja.net www.gov.scot
```

For comparison, whois.ja.net is already explicitly set within jwhois.conf for .gov.uk, also managed by Jisc.